### PR TITLE
fix: adding require to fix unit tests

### DIFF
--- a/lib/final-api.rb
+++ b/lib/final-api.rb
@@ -13,6 +13,8 @@ require 'metriks/reporter/graphite'
 require 'final-api/ddtf'
 require 'final-api/model_extensions'
 
+require 'test_aggregation'
+
 require 'sidekiq'
 require 'travis-sidekiqs'
 require 'sidekiq-status'


### PR DESCRIPTION
There was a require 'test_aggregation' missing, causing headache to
anyone trying to run unit tests (specs)
