### PR TITLE
fix: typo in final api config

### DIFF
--- a/lib/final-api.rb
+++ b/lib/final-api.rb
@@ -21,7 +21,7 @@ require 'travis/support/amqp'
 module FinalAPI
   class << self
     def config
-      @confg ||= FinalAPI::Config.load
+      @config ||= FinalAPI::Config.load
     end
 
     def logger


### PR DESCRIPTION
There was a typo in FinalAPI config accessor.
